### PR TITLE
datファイル内を相対パスで参照するとエラーが起きて参照できない #5修正

### DIFF
--- a/lib/neri.rb
+++ b/lib/neri.rb
@@ -1,2 +1,4 @@
 require "neri/version"
 require "neri/runtime"
+
+require"pathname"

--- a/lib/neri/ayame.rb
+++ b/lib/neri/ayame.rb
@@ -5,9 +5,9 @@ require "ayame" unless defined? Ayame
 module Neri
   module Ayame
     def new(filename)
-      return super unless Neri.exist_in_datafile?(filename)
+      return super unless Neri.exist_in_datafile?(Neri::Neri_virtual_path+filename)
 
-      load_from_memory(Neri.file_read(filename))
+      load_from_memory(Neri.file_read(Neri::Neri_virtual_path+filename))
     end
   end
 end

--- a/lib/neri/build.rb
+++ b/lib/neri/build.rb
@@ -590,7 +590,7 @@ options:
           #フルパスを取得
           fullpath = File.expand_path(file)
            
-          nputs virtual_file_path[0]
+         
           #ファイルパスがフルパスなら相対パスに変更
           #そうでないなら元のパスに戻す?
           filename = if fullpath.start_with?(rubydir)

--- a/lib/neri/dxruby.rb
+++ b/lib/neri/dxruby.rb
@@ -5,8 +5,9 @@ require "dxruby" unless defined? DXRuby
 module Neri
   module DXRubyImage
     def load(path, x = nil, y = nil, width = nil, height = nil)
-      return super unless Neri.exist_in_datafile?(path)
 
+      filepath=Pathname(ENV['Neri_virtual_path']+path).cleanpath.to_s.sub(%r{\./},"")
+      return super unless Neri.exist_in_datafile?(filepath)
       image = load_from_file_in_memory(Neri.file_read(path))
       image = image.slice(x, y, width, height) if x && y && width && height
       image
@@ -22,9 +23,8 @@ module Neri
 
   module DXRubySound
     def new(path)
-      return super unless Neri.exist_in_datafile?(path)
-
-      load_from_memory(Neri.file_read(path),
+      return super unless Neri.exist_in_datafile?((ENV['Neri_virtual_path']+path))
+      load_from_memory(Neri.file_read(+path),
                        File.extname(path) == ".mid" ? DXRuby::TYPE_MIDI : DXRuby::TYPE_WAV)
     end
   end
@@ -43,3 +43,4 @@ module DXRuby
     end
   end
 end
+"Neri_virtual_path/picture/exprode/1.png"

--- a/lib/neri/dxruby_tiled.rb
+++ b/lib/neri/dxruby_tiled.rb
@@ -7,7 +7,7 @@ module DXRuby
     module_function
 
     def read_file(file, encoding = Encoding::UTF_8)
-      Neri.file_read(file, encoding)
+      Neri.file_read(ENV['Neri_virtual_path']+file, encoding)
     end
   end
 end


### PR DESCRIPTION
以前issueで提案した修正方法で上記の問題を修正してみました。
私の環境では問題なく動きました。

おおむね#5で提案した通りに修正しました。
batファイルだけで確認しているのでもしかしたらexeで実行したら
バグが発生しているかもしれないです。

例のごとくコード自体はきれいではないのでこれを参考にして作り直してもらっても結構ですし、改変してマージしてもらっても結構です。

ご検討お願いします。


///以下issueで提案した内容
nodai2hITCさん修正お疲れさまでした。
すいませんがまた不具合を発見してしまいました。
特定のファイルを参照できないﾊﾞｸﾞです。

発生状況
D:/user/fujimura/programfiles
/src
　　　　/main.rb
　　　　/sub.rb
/data
/bgm
という構造のファイルがあり、/srcにはプログラムのソースmain,subが入っています。
D:/user/fujimura/programfiles/srcで
neri　main.rb ../* --no-exe
を実行して生成したファイルを用いるのが発生状況です。

ﾊﾞｸﾞの内容
今回のﾊﾞｸﾞでは
main.rbとおなじファイルに入っているプログラムsub1.rbが参照できません。
発生タイミングは
main.rb
から
require './sub1.rb'
を実行したときです。

調べたところsub1.rbは@filesの中に../src/sub1.rbをkeyとして存在してます。
これだとrequire './sub1.rb'で参照できません。
これが原因だと思われます

解決方法の提案
いろいろ考えたのですが結構根が深いようなと考えています。
多少手戻りがあるのですが

仮想的なファイルパスを用意しそこからの相対パス参照にすると解決できるかと思います。
どういうことかと言うと
今回の実装の変更の理由のついに
D:/user/fujimura/programfiles/src
というファイルパスで実行すると@fileの中にfujimuraという作成者の名前が見えてしまうからですよね。
このうち
D:/user/fujimura/programfilesまでを
neri_virtual_filepathと置き換えてファイルパスを
neri_virtual_filepath/src
として扱うようにします。
今までに近いような手法ですが、@file内ではneri_virtual_filepath/src/sub1.rb
として扱うようにします。
これだとrequire './sub1.rb'で参照するときに
私の大好きなpathnameを使って
neri_virtual_filepath/srcと./sub1.rbを足し合わせるようにします。
neri_virtual_filepath/src/sub1.rbとして@file内を参照するので
これで問題が解決できるかと思います。

この方法だとほかにも
../src/../src/sub1.rb
みたいなふざけた参照をされたとしても問題が発生しません。
また、セキュリティを気にしない場合に限りますが
neri_virtual_filepathをneri実行時に任意の文字列に変更できるようにする
例えばD:/user/fujimura/programfiles
にできるようにすることで
require 'D:/user/fujimura/programfiles/sub1.rb'
みたいな参照をしているプログラムでも動くようになります。
本当にセキュリティを気にしないようにする場合だけですが。

以上の手法で解決できると思うのですがどうでしょうか